### PR TITLE
update to latest esri-system-js to use same module names and typings

### DIFF
--- a/app/esri-map-view.component.ts
+++ b/app/esri-map-view.component.ts
@@ -1,6 +1,7 @@
 import { Component, ElementRef, Input, Output, EventEmitter } from '@angular/core';
 import { AnalysisMapService } from './map.service';
-import { Map, MapView } from 'esri-mods';
+import Map from 'esri/Map';
+import MapView from 'esri/views/MapView';
 
 @Component({
     selector: 'esri-map-view',

--- a/app/esri-scene-view.component.ts
+++ b/app/esri-scene-view.component.ts
@@ -1,7 +1,9 @@
 import { Component, ElementRef, Output, EventEmitter } from '@angular/core';
 import { SimpleMapService } from './map.service';
 import { ViewCoordinationService } from './view-coordination.service';
-import { Map, SceneView } from 'esri-mods';
+import Map from 'esri/Map';
+import SceneView from 'esri/views/SceneView';
+
 
 @Component({
     selector: 'esri-scene-view',

--- a/app/geometry-engine-showcase.component.ts
+++ b/app/geometry-engine-showcase.component.ts
@@ -7,7 +7,10 @@ import 'rxjs/add/operator/debounceTime';
 import 'rxjs/add/operator/distinctUntilChanged';
 
 import { EsriMapViewComponent } from './esri-map-view.component';
-import { geometryEngineAsync, Graphic, SimpleFillSymbol, SimpleLineSymbol } from 'esri-mods';
+import geometryEngineAsync from 'esri/geometry/geometryEngineAsync';
+import Graphic from 'esri/Graphic';
+import SimpleFillSymbol from  'esri/symbols/SimpleFillSymbol';
+import SimpleLineSymbol from 'esri/symbols/SimpleLineSymbol';
 
 @Component({
     selector: 'geometry-engine-showcase',

--- a/app/load.ts
+++ b/app/load.ts
@@ -2,7 +2,6 @@ declare var System: any;
 declare var esriSystem: any;
 
 // load Esri modules with the help of esri-system-js library
-// into a System.js module called esri-mods
 esriSystem.register([
     'esri/geometry/Point',
     'esri/geometry/geometryEngineAsync',
@@ -24,6 +23,4 @@ esriSystem.register([
     // System.import('app/main')
     System.import('app')
         .then(null, console.error.bind(console));
-}, {
-    outModuleName: 'esri-mods'
 });

--- a/app/map.service.ts
+++ b/app/map.service.ts
@@ -1,5 +1,7 @@
 import { Injectable } from '@angular/core';
-import { Map, FeatureLayer, GraphicsLayer } from 'esri-mods';
+import Map from 'esri/Map';
+import FeatureLayer from 'esri/layers/FeatureLayer';
+import GraphicsLayer from 'esri/layers/GraphicsLayer';
 
 @Injectable()
 export class SimpleMapService {

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
         "reflect-metadata": "^0.1.3",
         "rxjs": "5.0.0-beta.6",
         "zone.js": "^0.6.12",
-        "esri-system-js": "^0.0.2"
+        "esri-system-js": "^1.0.0-beta.0"
     },
     "devDependencies": {
         "concurrently": "^2.0.0",

--- a/systemjs.config.js
+++ b/systemjs.config.js
@@ -13,9 +13,6 @@
         },
         'rxjs': {
             defaultExtension: 'js'
-        },
-        'esri-mods': {
-            defaultExtension: 'js'
         }
     };
     var ngPackageNames = [

--- a/typings.json
+++ b/typings.json
@@ -1,5 +1,6 @@
 {
     "globalDependencies": {
+        "arcgis-js-api": "github:Esri/jsapi-resources/4.x/typescript/arcgis-js-api.d.ts",
         "core-js": "registry:dt/core-js#0.0.0+20160317120654",
         "jasmine": "registry:dt/jasmine#2.2.0+20160505161446",
         "node": "registry:dt/node#4.0.0+20160509154515"


### PR DESCRIPTION
update to esri-system-js v1.0.0-beta.0
import all esri modules using their full name
add ArcGIS API for JavaScript typings
